### PR TITLE
adding tests

### DIFF
--- a/tests/spec.go
+++ b/tests/spec.go
@@ -1,0 +1,66 @@
+package tests
+
+import (
+	"testing"
+)
+
+// Spec is an access point to test assertions
+type Spec struct {
+	t *testing.T
+}
+
+// TestingSpec generates a spec. You will want to use it once in a test file
+func TestingSpec(t *testing.T) *Spec {
+	return &Spec{t: t}
+}
+
+// AssertNil expects given value to be nil, or errors
+func (spec *Spec) AssertNil(actual interface{}) {
+	if actual == nil {
+		return
+	}
+	spec.t.Error("Expected %+v to be nil", actual)
+}
+
+// AssertNotNil expects given value to be not nil, or errors
+func (spec *Spec) AssertNotNil(actual interface{}) {
+	if actual != nil {
+		return
+	}
+	spec.t.Error("Expected %+v to be not nil", actual)
+}
+
+// AssertEquals expects given values to be equal (comparison via `==`), or errors
+func (spec *Spec) AssertEquals(actual, value interface{}) {
+	if actual == value {
+		return
+	}
+	spec.t.Error("Expected %+v, got %+v", value, actual)
+}
+
+// AssertNotEquals expects given values to be nonequal (comparison via `==`), or errors
+func (spec *Spec) AssertNotEquals(actual, value interface{}) {
+	if !(actual == value) {
+		return
+	}
+	spec.t.Error("Expected not %+v", value)
+}
+
+// AssertEqualsAny expects given actual to equal (comparison via `==`) at least one of given values, or errors
+func (spec *Spec) AssertEqualsAny(actual interface{}, values ...interface{}) {
+	for _, value := range values {
+		if actual == value {
+			return
+		}
+	}
+	spec.t.Error("Expected %+v to equal any of given values", actual)
+}
+
+// AssertNotEqualsAny expects given actual to be nonequal (comparison via `==`)tp any of given values, or errors
+func (spec *Spec) AssertNotEqualsAny(actual interface{}, values ...interface{}) {
+	for _, value := range values {
+		if actual == value {
+			spec.t.Error("Expected not %+v", value)
+		}
+	}
+}

--- a/tests/spec.go
+++ b/tests/spec.go
@@ -4,63 +4,73 @@ import (
 	"testing"
 )
 
-// Spec is an access point to test assertions
+// Spec is an access point to test Expections
 type Spec struct {
 	t *testing.T
 }
 
-// TestingSpec generates a spec. You will want to use it once in a test file
-func TestingSpec(t *testing.T) *Spec {
+// S generates a spec. You will want to use it once in a test file, once in a test or once per each check
+func S(t *testing.T) *Spec {
 	return &Spec{t: t}
 }
 
-// AssertNil expects given value to be nil, or errors
-func (spec *Spec) AssertNil(actual interface{}) {
+// ExpectNil expects given value to be nil, or errors
+func (spec *Spec) ExpectNil(actual interface{}) {
 	if actual == nil {
 		return
 	}
-	spec.t.Error("Expected %+v to be nil", actual)
+	spec.t.Errorf("Expected %+v to be nil", actual)
 }
 
-// AssertNotNil expects given value to be not nil, or errors
-func (spec *Spec) AssertNotNil(actual interface{}) {
+// ExpectNotNil expects given value to be not nil, or errors
+func (spec *Spec) ExpectNotNil(actual interface{}) {
 	if actual != nil {
 		return
 	}
-	spec.t.Error("Expected %+v to be not nil", actual)
+	spec.t.Errorf("Expected %+v to be not nil", actual)
 }
 
-// AssertEquals expects given values to be equal (comparison via `==`), or errors
-func (spec *Spec) AssertEquals(actual, value interface{}) {
+// ExpectEquals expects given values to be equal (comparison via `==`), or errors
+func (spec *Spec) ExpectEquals(actual, value interface{}) {
 	if actual == value {
 		return
 	}
-	spec.t.Error("Expected %+v, got %+v", value, actual)
+	spec.t.Errorf("Expected %+v, got %+v", value, actual)
 }
 
-// AssertNotEquals expects given values to be nonequal (comparison via `==`), or errors
-func (spec *Spec) AssertNotEquals(actual, value interface{}) {
+// ExpectNotEquals expects given values to be nonequal (comparison via `==`), or errors
+func (spec *Spec) ExpectNotEquals(actual, value interface{}) {
 	if !(actual == value) {
 		return
 	}
-	spec.t.Error("Expected not %+v", value)
+	spec.t.Errorf("Expected not %+v", value)
 }
 
-// AssertEqualsAny expects given actual to equal (comparison via `==`) at least one of given values, or errors
-func (spec *Spec) AssertEqualsAny(actual interface{}, values ...interface{}) {
+// ExpectEqualsAny expects given actual to equal (comparison via `==`) at least one of given values, or errors
+func (spec *Spec) ExpectEqualsAny(actual interface{}, values ...interface{}) {
 	for _, value := range values {
 		if actual == value {
 			return
 		}
 	}
-	spec.t.Error("Expected %+v to equal any of given values", actual)
+	spec.t.Errorf("Expected %+v to equal any of given values", actual)
 }
 
-// AssertNotEqualsAny expects given actual to be nonequal (comparison via `==`)tp any of given values, or errors
-func (spec *Spec) AssertNotEqualsAny(actual interface{}, values ...interface{}) {
+// ExpectNotEqualsAny expects given actual to be nonequal (comparison via `==`)tp any of given values, or errors
+func (spec *Spec) ExpectNotEqualsAny(actual interface{}, values ...interface{}) {
 	for _, value := range values {
 		if actual == value {
-			spec.t.Error("Expected not %+v", value)
+			spec.t.Errorf("Expected not %+v", value)
 		}
 	}
+}
+
+// ExpectFalse expects given values to be false, or errors
+func (spec *Spec) ExpectFalse(actual interface{}) {
+	spec.ExpectEquals(actual, false)
+}
+
+// ExpectTrue expects given values to be true, or errors
+func (spec *Spec) ExpectTrue(actual interface{}) {
+	spec.ExpectEquals(actual, true)
 }


### PR DESCRIPTION
This PR adds the `tests` package, a minimal wrapper on top of golang's `testing` package, along with utility functions such as:
- `ExpectNil`
- `ExpectEquals`
- `ExpectEqualsAny`
- `ExpectTrue`

etc.
