### PR TITLE
Add method to clear DB cache

### DIFF
--- a/sqlutils/sqlutils.go
+++ b/sqlutils/sqlutils.go
@@ -144,6 +144,17 @@ func GetDB(mysql_uri string) (*sql.DB, bool, error) {
 	return knownDBs[mysql_uri], exists, nil
 }
 
+// Resets the knownDBs cache, used when the DB connections have been closed,
+//   and new connections are needed to access the DB
+func ResetDBCache() {
+	knownDBsMutex.Lock()
+	defer func() {
+		knownDBsMutex.Unlock()
+	}()
+
+	knownDBs = make(map[string]*sql.DB)
+}
+
 // RowToArray is a convenience function, typically not called directly, which maps a
 // single read database row into a NullString
 func RowToArray(rows *sql.Rows, columns []string) []CellData {


### PR DESCRIPTION
This relates to https://github.com/github/gh-ost/issues/465 and a PR I'm about to submit to allow gh-ost to be consumed as a library.

When using `gh-ost` in a long running process, the DB connections get closed but due to the caching here, subsequent migrations fail because the connection has already been closed. This PR exposes a function that can be used to reset the cache, allowing new connections to be established when necessary. This method would typically be called as a part of teardown from the consumer